### PR TITLE
Dynamic Intensity Filtering

### DIFF
--- a/src/lidar_processor.cpp
+++ b/src/lidar_processor.cpp
@@ -98,20 +98,20 @@ void LidarProcessor::passthrough_stage(pcl::PointCloud<pcl::PointXYZI>::Ptr clou
   double mean_intensity;
 
   // Calculate statistics
-  for (pcl::PointCloud<pcl::PointXYZI>::iterator it = cloud->begin(); it != cloud->end(); it++)
+  for (auto& point : *cloud)
   {
-    if (it->intensity < min_intensity) min_intensity = it->intensity;
-    if (it->intensity > max_intensity) max_intensity = it->intensity;
-    sum_of_intensity = sum_of_intensity + it->intensity;
+    if (point.intensity < min_intensity) min_intensity = point.intensity;
+    if (point.intensity > max_intensity) max_intensity = point.intensity;
+    sum_of_intensity = sum_of_intensity + point.intensity;
     sample_size = sample_size + 1;
   }
   mean_intensity = sum_of_intensity / sample_size;
 
   // calc standard dev
   double numerator = 0.0;
-  for (pcl::PointCloud<pcl::PointXYZI>::iterator it = cloud->begin(); it != cloud->end(); it++)
+  for (auto& point : *cloud)
   {
-    numerator = it->intensity - mean_intensity;
+    numerator = point.intensity - mean_intensity;
   }
   double std_dev_intensity = sqrt((numerator * numerator) / sample_size);
   double threshold = mean_intensity - (2 * std_dev_intensity);


### PR DESCRIPTION
The passthrough filter in PCL needs several parameters to effectively filter low intensities because of differences in intensity values returned by simulation and even multiple LiDAR vendors.

My approach is a simple statistical outlier filter, with all intensities 2-sigma below the mean as being outliers. Additional tuning may be needed, but this approach does not require configuration as it is entirely dependent on the actual data sample (input pointcloud)